### PR TITLE
PuppetToken_Audit_Report_Maourotis

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   ],
   "scripts": {
     "test": "FOUNDRY_PROFILE=dev forge test -vvvvv",
-    "test:dev": "FOUNDRY_PROFILE=dev forge test --match-contract RewardRouterTest -vvvvv",
+    "test:dev": "FOUNDRY_PROFILE=dev forge test --match-contract PuppetTokenTest -vvvvv",
     "test:dev:fork": "FOUNDRY_PROFILE=dev forge test --match-contract PositionRouterTest -vvvvv --fork-url https://arb-mainnet.g.alchemy.com/v2/RBsflxWv6IhITsLxAWcQlhCqSuxV7Low --fork-block-number 192315592",
     "build": "forge build --sizes",
     "build:dev": "FOUNDRY_PROFILE=dev forge build --sizes",

--- a/src/token/PuppetToken.sol
+++ b/src/token/PuppetToken.sol
@@ -19,7 +19,7 @@ import {IAuthority} from "./../utils/interfaces/IAuthority.sol";
  */
 contract PuppetToken is Permission, ERC20 {
     event PuppetToken__SetConfig(Config config);
-    event PuppetToken__MintCore(address operator, address receiver, uint amount);
+    event PuppetToken__MintCore(address operator, address indexed receiver, uint amount);
 
     uint private constant CORE_RELEASE_DURATION_DIVISOR = 31560000; // 1 year
     uint private constant GENESIS_MINT_AMOUNT = 100_000e18;

--- a/src/token/PuppetToken.sol
+++ b/src/token/PuppetToken.sol
@@ -95,14 +95,14 @@ contract PuppetToken is Permission, ERC20 {
      */
     function mintCore(address _receiver) external auth returns (uint) {
         uint _lastMintTime = lastMintTime;
-        uint mintableAmount = getMintableCoreAmount(_lastMintTime);
+        uint _mintableAmount = getMintableCoreAmount(_lastMintTime);
 
-        mintedCoreAmount += mintableAmount;
-        _mint(_receiver, mintableAmount);
+        mintedCoreAmount += _mintableAmount;
+        _mint(_receiver, _mintableAmount);
 
-        emit PuppetToken__MintCore(msg.sender, _receiver, mintableAmount);
+        emit PuppetToken__MintCore(msg.sender, _receiver, _mintableAmount);
 
-        return mintableAmount;
+        return _mintableAmount;
     }
 
     /**

--- a/src/token/PuppetToken.sol
+++ b/src/token/PuppetToken.sol
@@ -56,12 +56,12 @@ contract PuppetToken is Permission, ERC20 {
     }
 
     function getMintableCoreAmount(uint _lastMintTime) public view returns (uint) {
-        uint totalMinedAmount = totalSupply() -  mintedCoreAmount - GENESIS_MINT_AMOUNT;
-        uint maxMintableAmount = Precision.applyFactor(getCoreShare(_lastMintTime), totalMinedAmount);
+        uint _totalMinedAmount = totalSupply() -  mintedCoreAmount - GENESIS_MINT_AMOUNT;
+        uint _maxMintableAmount = Precision.applyFactor(getCoreShare(_lastMintTime), _totalMinedAmount);
 
-        if (maxMintableAmount < mintedCoreAmount) revert PuppetToken__CoreShareExceedsMining();
+        if (_maxMintableAmount < mintedCoreAmount) revert PuppetToken__CoreShareExceedsMining();
 
-        return maxMintableAmount - mintedCoreAmount;
+        return _maxMintableAmount - mintedCoreAmount;
     }
 
     /**


### PR DESCRIPTION
- [M-1] as discussed, the shares reductions has to cover total mined supply
- [L-1] introduced lastMintTime which obsolete other variables
- [L-2] done
- [I-3] uint is preferable for personal readability, uint256, int256 are highly optimized which is used for almost all operations. let me know if thats agreeable
- [G-1] done, set to immutable
- [G-2] done